### PR TITLE
chore(pnpm): align workspace package metadata

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,11 +1,11 @@
 {
   "name": "client",
   "version": "2.12.1",
+  "private": true,
   "main": "app/index.tsx",
   "homepage": "https://pure-js.github.io/self-hosted-microblogging/",
   "type": "module",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "dev": "vite serve",
     "build": "vite build",
     "preview": "vite preview",
@@ -67,10 +67,9 @@
   ],
   "engines": {
     "node": ">=20.9",
-    "pnpm": ">=9.8"
+    "pnpm": ">=11"
   },
   "msw": {
     "workerDirectory": "public"
-  },
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
+  }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -50,5 +50,9 @@
     "extends": [
       "plugin:storybook/recommended"
     ]
-  }
+  },
+  "engines": {
+    "pnpm": ">=11"
+  },
+  "packageManager": "pnpm@11"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "self-hosted-microblogging",
   "version": "2.12.3",
+  "private": true,
   "description": "Self-hosted Microblogging Frontend App",
   "main": "apps/client/app/index.tsx",
   "homepage": "https://pure-js.github.io/self-hosted-microblogging/",


### PR DESCRIPTION
## Summary

- mark the workspace root and client package as private to avoid accidental publishes
- align docs and client packages to the root pnpm toolchain (pnpm >= 11)
- drop per-package `preinstall` and `packageManager` declarations so everything defers to the root configuration